### PR TITLE
Modified the framer module to use dedicated properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ layer = new SVGLayer
 Then paste in what the Sketch plugin copied, which will look something like this:
 
 ```coffee
-layer = new SVGLayer.create
+layer = new SVGLayer
   strokeWidth: 4
-  width: 502.6700134277344
-  height: 204.3515625057028
-  path: '<path d="M0,204.351562 C0,204.351562 383.764204,204.390625 502.670013,0"></path>'
+  width: 324
+  height: 324
+  path: '<path d="M162,324 C251.470129,324 324,251.470129 324,162 C324,72.5298705 251.470129,0 162,0 C72.5298705,0 0,72.5298705 0,162 C0,251.470129 72.5298705,324 162,324 Z"></path>'
 ```
 
 ###### Animation
@@ -35,6 +35,7 @@ Use dashOffset to animate a path from start to end.
 ```coffee
 layer = new SVGLayer
   dashOffset: 0
+  # include other constructor options from example above
 
 layer.animate
   properties:

--- a/README.md
+++ b/README.md
@@ -11,35 +11,48 @@ Install the Sketch Plugin; select any path layer and run it. This automatically 
 
 In Framer Studio, after installing the module and importing it, create SVGLayers like so
 
-    layer = new SVGLayer.create
+```coffee
+{SVGLayer} = require "SVGLayer"
+
+layer = new SVGLayer
+```
 
 Then paste in what the Sketch plugin copied, which will look something like this:
 
-    layer = new SVGLayer.create
-      strokeWidth: 4
-      width: 502.6700134277344
-      height: 204.3515625057028
-      path: '<path d="M0,204.351562 C0,204.351562 383.764204,204.390625 502.670013,0"></path>'
+```coffee
+layer = new SVGLayer.create
+  strokeWidth: 4
+  width: 502.6700134277344
+  height: 204.3515625057028
+  path: '<path d="M0,204.351562 C0,204.351562 383.764204,204.390625 502.670013,0"></path>'
+```
 
 ###### Animation
-Use **layer.animatePath()** to animate a path from start to end.
+Use dashOffset to animate a path from start to end.
 
 ![line animating](https://dl.dropboxusercontent.com/u/1603978/svgAnimate.gif)
 
-Alternatively, you can pass in properties to specify the direction and animation curve/time
+```coffee
+layer = new SVGLayer
+  dashOffset: 0
 
-    layer.animatePath
-      curve: "ease-out"
-      time: 0.33
-      direction: "backward"
+layer.animate
+  properties:
+    dashOffset: 1
+```
 
+[View example using states](http://share.framerjs.com/tyizdr085xj8/)
+
+###### Properties
+
+- **`linecap`** *\<string>* (options: "round", "square", "butt")
+- **`fill`** *\<string>* (css color)
+- **`stroke`** *\<string>* (css color)
+- **`strokeWidth`** *\<string>*
+- **`dashOffset`** *\<string>* (from -1 to 1, defaults to 0)
 
 ###### Utils
 Use **layer.pathLength** to get the length of the SVG path
-
-
-###### The bad parts
-First the bad parts: animating SVGs is still a little less than ideal; it’s essentially a hack. This method, while clever, relies on changing the perspective property of the layer. While this is very rarely used, there might be some cases where modifying that property on an SVG layer breaks the out of box behavior of this module. It also uses layer states to drive the animation.
 
 ###### Tutorial
 Head over to Medium to read [Working with SVG Paths in Framer](https://medium.com/@joshpuckett/working-with-svg-paths-in-framer-43d3c2d08adc "Working with SVG Paths in Framer").


### PR DESCRIPTION
I played with the module a bit and came up with these possible improvements:
- use dedicated properties so we don't need to make use of perspective
- wait for the DOM to be ready before calculating the pathLength

As a result the familiar way of animating properties can be used which makes it also compatible with states.

Thanks for the great module Josh!
