### PR TITLE
Add the ability to shrink an SVG path forwards or backwards.

### DIFF
--- a/SVGLayer/SVGLayer.coffee
+++ b/SVGLayer/SVGLayer.coffee
@@ -48,6 +48,12 @@ class exports.create extends Layer
 			else if @direction == "backward"
 				dashOffset = Utils.modulate(@.perspective, [0, 1], [pathLength, pathLength*2])
 				@.style['stroke-dashoffset'] = dashOffset
+			else if @direction == "shrinkforward"
+				dashOffset = Utils.modulate(@.perspective, [1, 0], [pathLength, 0])
+				@.style['stroke-dashoffset'] = dashOffset
+			else if @direction == "shrinkbackward"
+				dashOffset = Utils.modulate(@.perspective, [1, 0], [pathLength, pathLength*2])
+				@.style['stroke-dashoffset'] = dashOffset
 
 	animatePath: (options={}) =>
 		options.direction ?= "forward"


### PR DESCRIPTION
This library is great! I added a couple of shrink methods to achieve this effect

![spinpuckett](https://cloud.githubusercontent.com/assets/438160/13206062/ab2b083c-d95b-11e5-923c-410d91cbf45a.gif)

The only issue with it is that I have to hide the path at the end as it leaves a small dot which marks the start of the path:

![shrinkforwards](https://cloud.githubusercontent.com/assets/438160/13206085/3d857f78-d95c-11e5-8bc6-055f520ca3ea.gif)
